### PR TITLE
removed extra Wire.write lines from readTemperature

### DIFF
--- a/src/ClosedCube_Si7051.cpp
+++ b/src/ClosedCube_Si7051.cpp
@@ -53,15 +53,12 @@ float ClosedCube_Si7051::readT() {
 float ClosedCube_Si7051::readTemperature() {
 	Wire.beginTransmission(_address);
 	Wire.write(0xF3);
-	Wire.write(_address);
-	Wire.write(_address);
-	Wire.write(_address);
 	Wire.endTransmission();
 
 	delay(10);
 
 	Wire.requestFrom(_address, (uint8_t)2);
-
+	
 	byte msb = Wire.read();
 	byte lsb = Wire.read();
 


### PR DESCRIPTION
The three Wire.write(_address) lines in readTemperature do not cause issues with
Arduino + Si7051 breakout board, but they also aren’t needed.
Porting the library to use with Particle Photon identified these lines
as causing i2c communication issues which were resolved by removing
these three lines: see
https://community.particle.io/t/si7051-sensor-code-i2c-arduino-particle-help-solved/29154/10