### PR TITLE
Bug on Wire.write for 0x0

### DIFF
--- a/src/ClosedCube_Si7051.cpp
+++ b/src/ClosedCube_Si7051.cpp
@@ -42,7 +42,7 @@ void ClosedCube_Si7051::begin(uint8_t address) {
 
 	Wire.beginTransmission(_address);
 	Wire.write(0xE6);
-	Wire.write(0x0);
+	Wire.write(byte(0));
 	Wire.endTransmission();
 }
 


### PR DESCRIPTION
Compile phase fails when writing 0x0 on Wire, replacing the hex value with a 0 byte fix the issue. I'm using a nRF52 BSP for Arduino.

More details here: https://github.com/arduino/Arduino/issues/6107